### PR TITLE
[FIX] #5 move ExtensionManagementUtility::addStaticFile

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,16 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+use \TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+call_user_func(function () {
+    /**
+     * Extension key
+     */
+    $extensionKey = 'er24_rechtstexte';
+
+    /**
+     * Add default TypoScript (constants and setup)
+     */
+    ExtensionManagementUtility::addStaticFile($extensionKey, 'Configuration/TypoScript', 'eRecht24 Rechtstexte Extension');
+});

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -37,7 +37,5 @@ call_user_func(
 
         }
 
-        \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('er24_rechtstexte', 'Configuration/TypoScript', 'eRecht24 Rechtstexte Extension');
-
     }
 );


### PR DESCRIPTION
This should fix ISSUE #5 and make Compatibility Check working again. Currently this extensions breaks updates when using typo3cms upgrade:prepare in TYPO3 Console. InstallTool also says, this extension is broken.