### PR TITLE
Use associative array keys for TCA items

### DIFF
--- a/Configuration/TCA/Overrides/tt_content_er24rechtstexte_main.php
+++ b/Configuration/TCA/Overrides/tt_content_er24rechtstexte_main.php
@@ -5,9 +5,9 @@ defined('TYPO3') || die();
     'tt_content',
     'CType',
     [
-        'LLL:EXT:er24_rechtstexte/Resources/Private/Language/locallang_db.xlf:tx_er24_rechtstexte_main.name',
-        'er24rechtstexte_main',
-        'ext-er24-rechtstexte-plugin-main'
+        'label' => 'LLL:EXT:er24_rechtstexte/Resources/Private/Language/locallang_db.xlf:tx_er24_rechtstexte_main.name',
+        'value' => 'er24rechtstexte_main',
+        'icon' => 'ext-er24-rechtstexte-plugin-main'
     ]
 );
 


### PR DESCRIPTION
This PR migrates the `items` definition of `ExtensionManagementUtility::addTcaSelectItem()` by switching to associative array keys.

See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.3/Feature-99739-AssociativeArrayKeysForTCAItems.html